### PR TITLE
Removed Apache metrics

### DIFF
--- a/doc/user/source/appendix_metrics.rst
+++ b/doc/user/source/appendix_metrics.rst
@@ -23,11 +23,6 @@ System metrics
 
 .. include:: metrics/system.rst
 
-Apache metrics
-++++++++++++++
-
-.. include:: metrics/apache.rst
-
 Nginx metrics
 +++++++++++++
 

--- a/doc/user/source/metrics/apache.rst
+++ b/doc/user/source/metrics/apache.rst
@@ -1,5 +1,9 @@
 Apache metrics
 ^^^^^^^^^^^^^^
+A collection of Apache metrics.
+
+.. note: Those metrics are not collected by StackLight 1.0 in MCP 0.5.
+
 .. _apache_metrics:
 
 * ``apache_bytes``, the number of bytes per second transmitted by the server.


### PR DESCRIPTION
The Apache metrics are not collected by SL 1.0 in MCP 0.5.